### PR TITLE
Add support for multiple channel targets

### DIFF
--- a/serverbot/config_example.py
+++ b/serverbot/config_example.py
@@ -4,8 +4,14 @@ Copy to config.py and adjust for your needs.
 
 # Name of your server as it appears on the website, e.g. Kadan
 target_server = ''
-# webhook URL for the Discord channel you want to send to
-webhook_url = ''
+# webhook URLs for the Discord channels you want to send to
+# messages are send to all channels in this list
+webhook_urls = [
+
+]
+# Migration notice:
+# the old config key webhook_url is still supported, messages will be send to webhook_url as well
+# you should move to webhook_urls
 
 up_message = '@everyone The server is now up (probably) :)'
 down_message = 'The server is now down :('

--- a/serverbot/serverbot.py
+++ b/serverbot/serverbot.py
@@ -25,7 +25,7 @@
 # tested with python 3.8
 
 """
-This bot sends a message to a Discord channel every time the
+This bot sends a message to Discord channels every time the
 configured Lost Ark server changes state between up and down.
 The down notification has a slight delay to correct for
 AGS issues where the status page sometimes bugs out.
@@ -124,15 +124,25 @@ def send_message(is_up):
     message = up_message
     if is_up == False:
         message = down_message
+    hook_list = []
     try:
-        req = requests.post(
-            webhook_url,
-            data=bytes(json.dumps({'content': message}), encoding='utf-8'),
-            headers = {'Content-Type': 'application/json'}
-        )
-        print(req.text)
-    except Exception as e:
-        print(e)
+        hook_list.append(webhook_url)
+    except:
+        pass
+    try:
+        hook_list.extend(webhook_urls)
+    except:
+        pass
+    for url in hook_list:
+        try:
+            req = requests.post(
+                url,
+                data=bytes(json.dumps({'content': message}), encoding='utf-8'),
+                headers = {'Content-Type': 'application/json'}
+            )
+            print(req.text)
+        except Exception as e:
+            print(e)
 
 
 def checkerloop():


### PR DESCRIPTION
Migration note:
Your old config will continue to work, but you should migrate to the
new webhook_urls config keys. Support for webhook_url will be
removed at some point in the future.